### PR TITLE
Improve how the lambda returns the success/error messages

### DIFF
--- a/src/migrationsHandler.ts
+++ b/src/migrationsHandler.ts
@@ -52,14 +52,17 @@ export class MigrationsHandler {
 
     if (pending.length === 0) {
       this.sequelize.close();
-      return 'No pending migrations to apply';
+      return { message: 'No pending migrations to apply' };
     }
 
     const migrations = await this.umzug.up();
     const migrationNames = migrations.map((migration) => migration.name);
     this.sequelize.close();
 
-    return `Succesfully applied ${migrations.length} migrations:\n${migrationNames.join('\n')}`;
+    return {
+      message: `Succesfully applied ${migrations.length} migrations`,
+      migrations: migrationNames,
+    };
   }
 
   public async rollback() {
@@ -67,12 +70,12 @@ export class MigrationsHandler {
 
     if (executed.length === 0) {
       this.sequelize.close();
-      return 'No executed migrations to rollback';
+      return { message: 'No executed migrations to rollback' };
     }
 
     const migration = await this.umzug.down();
     this.sequelize.close();
-    return `Succesfully rollbacked ${migration?.[0]?.name}`;
+    return { message: `Succesfully rollbacked ${migration?.[0]?.name}` };
   }
 
   public async reset() {
@@ -80,13 +83,16 @@ export class MigrationsHandler {
 
     if (executed.length === 0) {
       this.sequelize.close();
-      return 'No executed migrations to rollback';
+      return { message: 'No executed migrations to rollback' };
     }
 
     const migrations = await this.umzug.down({ to: 0 as const });
     const migrationNames = migrations.map((migration) => migration.name);
     this.sequelize.close();
 
-    return `Succesfully rollbacked ${migrations.length} migrations:\n${migrationNames.join('\n')}`;
+    return {
+      message: `Succesfully rollbacked ${migrations.length} migrations`,
+      migrations: migrationNames,
+    };
   }
 }

--- a/test/createHandler.test.ts
+++ b/test/createHandler.test.ts
@@ -23,14 +23,20 @@ describe('Tests for createHandler', () => {
     const handler = createHandler('migrate');
     expect(handler).toBeDefined();
 
-    jest
-      .spyOn(MigrationsHandler.prototype, 'migrate')
-      .mockReturnValue(Promise.resolve('Succesfully applied 2 migrations:\ntest1\ntest2'));
+    jest.spyOn(MigrationsHandler.prototype, 'migrate').mockReturnValue(
+      Promise.resolve({
+        message: 'Succesfully applied 2 migrations',
+        migrations: ['test1', 'test2'],
+      }),
+    );
 
     const callback = jest.fn();
 
     await handler({}, dummyContext, callback);
-    expect(callback).toHaveBeenCalledWith(null, 'Succesfully applied 2 migrations:\ntest1\ntest2');
+    expect(callback).toHaveBeenCalledWith(null, {
+      message: 'Succesfully applied 2 migrations',
+      migrations: ['test1', 'test2'],
+    });
   });
 
   it('should return the handler and throw an error', async () => {

--- a/test/migrationsHandler.test.ts
+++ b/test/migrationsHandler.test.ts
@@ -24,21 +24,26 @@ describe('Migrations Handler tests', () => {
 
   it('Should return that there are no pending migrations to apply', () => {
     jest.spyOn(Umzug.prototype, 'pending').mockReturnValue(Promise.resolve([]));
-    expect(migrationsHandler.migrate()).resolves.toBe('No pending migrations to apply');
+    expect(migrationsHandler.migrate()).resolves.toStrictEqual({
+      message: 'No pending migrations to apply',
+    });
   });
 
   it('Should migrate correctly', () => {
     jest.spyOn(Umzug.prototype, 'up').mockReturnValue(Promise.resolve(migrations));
     jest.spyOn(Umzug.prototype, 'pending').mockReturnValue(Promise.resolve(migrations));
 
-    expect(migrationsHandler.migrate()).resolves.toBe(
-      'Succesfully applied 2 migrations:\ntest1\ntest2',
-    );
+    expect(migrationsHandler.migrate()).resolves.toStrictEqual({
+      message: 'Succesfully applied 2 migrations',
+      migrations: ['test1', 'test2'],
+    });
   });
 
   it('Should return that there are no executed migrations to rollback', () => {
     jest.spyOn(Umzug.prototype, 'executed').mockReturnValue(Promise.resolve([]));
-    expect(migrationsHandler.rollback()).resolves.toBe('No executed migrations to rollback');
+    expect(migrationsHandler.rollback()).resolves.toStrictEqual({
+      message: 'No executed migrations to rollback',
+    });
   });
 
   it('Should rollback correctly', () => {
@@ -47,20 +52,25 @@ describe('Migrations Handler tests', () => {
     jest.spyOn(Umzug.prototype, 'down').mockReturnValue(Promise.resolve([migration]));
     jest.spyOn(Umzug.prototype, 'executed').mockReturnValue(Promise.resolve([migration]));
 
-    expect(migrationsHandler.rollback()).resolves.toBe('Succesfully rollbacked test1');
+    expect(migrationsHandler.rollback()).resolves.toStrictEqual({
+      message: 'Succesfully rollbacked test1',
+    });
   });
 
   it('Should return that there are no executed migrations to reset', () => {
     jest.spyOn(Umzug.prototype, 'executed').mockReturnValue(Promise.resolve([]));
-    expect(migrationsHandler.reset()).resolves.toBe('No executed migrations to rollback');
+    expect(migrationsHandler.reset()).resolves.toStrictEqual({
+      message: 'No executed migrations to rollback',
+    });
   });
 
   it('Should reset correctly', () => {
     jest.spyOn(Umzug.prototype, 'down').mockReturnValue(Promise.resolve(migrations));
     jest.spyOn(Umzug.prototype, 'executed').mockReturnValue(Promise.resolve(migrations));
 
-    expect(migrationsHandler.reset()).resolves.toBe(
-      'Succesfully rollbacked 2 migrations:\ntest1\ntest2',
-    );
+    expect(migrationsHandler.reset()).resolves.toStrictEqual({
+      message: 'Succesfully rollbacked 2 migrations',
+      migrations: ['test1', 'test2'],
+    });
   });
 });


### PR DESCRIPTION
## What I did
Improve how the lambda returns the success/error messages

## How I did it
Changed the return statement in the MigrationsHandler. Now the response structure is the following:
```typescript
{
  message: String,
  migrations?: [String]
}
```

## How to test it
Run `npm test`
